### PR TITLE
Add viewing functionality for groups

### DIFF
--- a/src/main/java/seedu/address/model/group/Group.java
+++ b/src/main/java/seedu/address/model/group/Group.java
@@ -71,6 +71,17 @@ public class Group {
         this.eventIDs = events;
     }
 
+    /**
+     * Returns a string representation of member IDs.
+     * @return string representation
+     */
+    public String printEventIds() {
+        String result = "event IDs: ";
+        for (int i = 0; i < this.eventIDs.size(); i++) {
+            result += this.eventIDs.get(i) + " ";
+        }
+        return result;
+    }
 
     /**
      * Returns a String output with all the names in a single line separated by whitespace.
@@ -78,7 +89,7 @@ public class Group {
      * @return
      */
     public String printMemberList() {
-        String build = "";
+        String build = "members: ";
         for (int i = 0; i < memberIDs.size(); i++) {
             build += memberIDs.get(i) + " ";
         }

--- a/src/main/java/seedu/address/ui/GroupCard.java
+++ b/src/main/java/seedu/address/ui/GroupCard.java
@@ -24,6 +24,10 @@ public class GroupCard extends UiPart<Region> {
     private Label id;
     @FXML
     private Label timeSpent;
+    @FXML
+    private Label members;
+    @FXML
+    private Label events;
 
     public GroupCard(Group group, int displayedIndex) {
         super(FXML);
@@ -32,6 +36,8 @@ public class GroupCard extends UiPart<Region> {
         name.setText(group.getName().fullName);
         String text = group.getTimeSpent().toString();
         timeSpent.setText("Total Time Spent:" + text);
+        members.setText(group.printMemberList());
+        events.setText(group.printEventIds());
     }
 
     @Override

--- a/src/main/resources/view/GroupListCard.fxml
+++ b/src/main/resources/view/GroupListCard.fxml
@@ -27,6 +27,8 @@
                 <Label fx:id="name" text="\$first" styleClass="cell_big_label" />
             </HBox>
             <Label fx:id="timeSpent" text="\$timeSpent" styleClass="cell_small_label" />
+            <Label fx:id="members" text="\$members" styleClass="cell_small_label" />
+            <Label fx:id="events" text="\$events" styleClass="cell_small_label" />
         </VBox>
     </GridPane>
 </HBox>

--- a/src/test/java/seedu/address/model/UniqueEventListTest.java
+++ b/src/test/java/seedu/address/model/UniqueEventListTest.java
@@ -1,0 +1,22 @@
+package seedu.address.model;
+
+import static seedu.address.testutil.Assert.assertThrows;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.address.model.event.UniqueEventList;
+
+public class UniqueEventListTest {
+
+    private final UniqueEventList uniqueEventList = new UniqueEventList();
+
+    @Test
+    public void contains_nullEvent_throwsNullPointerException() {
+        assertThrows(NullPointerException.class, () -> uniqueEventList.contains(null));
+    }
+
+    @Test
+    public void remove_nullEvent_throwsNullPointerException() {
+        assertThrows(NullPointerException.class, () -> uniqueEventList.remove(null));
+    }
+}

--- a/src/test/java/seedu/address/model/group/UniqueGroupListTest.java
+++ b/src/test/java/seedu/address/model/group/UniqueGroupListTest.java
@@ -13,24 +13,24 @@ public class UniqueGroupListTest {
     private final UniqueGroupList uniqueGroupList = new UniqueGroupList();
 
     @Test
-    public void contains_nullPerson_throwsNullPointerException() {
+    public void contains_nullGroup_throwsNullPointerException() {
         assertThrows(NullPointerException.class, () -> uniqueGroupList.contains(null));
     }
 
     @Test
-    public void remove_nullPerson_throwsNullPointerException() {
+    public void remove_nullGroup_throwsNullPointerException() {
         assertThrows(NullPointerException.class, () -> uniqueGroupList.removeGroup(null));
     }
 
     @Test
-    public void contains_personInList_returnsTrue() {
+    public void contains_groupInList_returnsTrue() {
         Group group = new Group(new Name("Soc Friends"));
         uniqueGroupList.addGroup(group);
         assertTrue(uniqueGroupList.contains(group));
     }
 
     @Test
-    public void add_duplicatePerson_throwsDuplicatePersonException() {
+    public void add_duplicateGroup_throwsDuplicateGroupException() {
         Group group = new Group(new Name("Soc Friends"));
         uniqueGroupList.addGroup(group);
         assertThrows(DuplicateGroupException.class, () -> uniqueGroupList.addGroup(group));


### PR DESCRIPTION
This PR addresses is work in progress to address #39 and #40. Activities are the "names" of events, and in the future as UniqueEventList becomes functional, eventIDs will be replaced by activities. Similarly for places, their info would also come from UniqueEventList. 

As an improvement, Member names should be displayed instead of MemberIDs. 