### PR TITLE
Add `edit_group` functionality

### DIFF
--- a/src/main/java/seedu/address/logic/commands/AddEventCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddEventCommand.java
@@ -65,6 +65,10 @@ public class AddEventCommand extends Command {
         this.toAdd = event;
     }
 
+    public Event getToAdd() {
+        return this.toAdd;
+    }
+
     @Override
     public CommandResult execute(Model model) throws CommandException {
         requireAllNonNull(model);
@@ -122,8 +126,20 @@ public class AddEventCommand extends Command {
 
     @Override
     public boolean equals(Object other) {
-        return other == this // short circuit if same object
-                || (other instanceof AddEventCommand // instanceof handles nulls
-                && toAdd.equals(((AddEventCommand) other).toAdd));
+        if (other == this) {
+            return true;
+        }
+
+        if (!(other instanceof AddEventCommand)) {
+            return false;
+        }
+
+        AddEventCommand e = (AddEventCommand) other;
+
+        return this.toAdd.getActivity().equalsIgnoreCase(e.getToAdd().getActivity())
+                && this.toAdd.getPlace().equalsIgnoreCase(e.getToAdd().getPlace())
+                && this.toAdd.getTime().equals(e.getToAdd().getTime())
+                && this.toAdd.getWithGroup().equals(e.getToAdd().getWithGroup())
+                && this.toAdd.getWithPerson().equals(e.getToAdd().getWithPerson());
     }
 }

--- a/src/main/java/seedu/address/logic/commands/EditCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditCommand.java
@@ -69,7 +69,7 @@ public class EditCommand extends Command {
     public static final String MESSAGE_EDIT_PERSON_SUCCESS = "Edited Person: %1$s";
     public static final String MESSAGE_NOT_EDITED = "At least one field to edit must be provided.";
     public static final String MESSAGE_DUPLICATE_PERSON =
-            "This person already exists in the address book.";
+            "This person already exists in the Coder Life Insights.";
 
     private final Index index;
     private final EditPersonDescriptor editPersonDescriptor;

--- a/src/main/java/seedu/address/logic/commands/EditGroupCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditGroupCommand.java
@@ -21,7 +21,7 @@ import seedu.address.model.person.Time;
 /**
  * Represents the command to edit a group in Coder Life Insights.
  */
-public class EditGroupCommand extends Command{
+public class EditGroupCommand extends Command {
 
     public static final String COMMAND_WORD = "edit_group";
 
@@ -102,13 +102,13 @@ public class EditGroupCommand extends Command{
         }
 
         ArrayList<Integer> eventIds = groupToEdit.getEvents();
-        int groupID = groupToEdit.getGroupId();
+        int groupId = groupToEdit.getGroupId();
 
         Group modifiedGroup = new Group(updatedName);
         modifiedGroup.setTimeSpent(oldTime);
         modifiedGroup.setMemberIDs(memberIds);
         modifiedGroup.setEventIDs(eventIds);
-        modifiedGroup.setGroupId(groupID);
+        modifiedGroup.setGroupId(groupId);
 
         return modifiedGroup;
     }

--- a/src/main/java/seedu/address/logic/commands/EditGroupCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditGroupCommand.java
@@ -1,0 +1,153 @@
+package seedu.address.logic.commands;
+
+import static java.util.Objects.requireNonNull;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_MEMBER;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
+import static seedu.address.model.Model.PREDICATE_SHOW_ALL_GROUPS;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+import seedu.address.commons.core.Messages;
+import seedu.address.commons.core.index.Index;
+import seedu.address.commons.util.CollectionUtil;
+import seedu.address.logic.commands.exceptions.CommandException;
+import seedu.address.model.Model;
+import seedu.address.model.group.Group;
+import seedu.address.model.person.Name;
+import seedu.address.model.person.Time;
+
+/**
+ * Represents the command to edit a group in Coder Life Insights.
+ */
+public class EditGroupCommand extends Command{
+
+    public static final String COMMAND_WORD = "edit_group";
+
+    public static final String MESSAGE_USAGE =
+            COMMAND_WORD
+                    + ": Edits the details of the group identified "
+                    + "by the index number used in the displayed group list. "
+                    + "Existing values will be overwritten by the input values.\n"
+                    + "Parameters: INDEX (must be a positive integer) "
+                    + "["
+                    + PREFIX_NAME
+                    + "NAME] "
+                    + "["
+                    + PREFIX_MEMBER
+                    + "MEMBERS]...\n"
+                    + "Example: "
+                    + COMMAND_WORD
+                    + " 1 "
+                    + PREFIX_NAME
+                    + "SoC Friends "
+                    + PREFIX_MEMBER
+                    + "1"
+                    + PREFIX_MEMBER
+                    + "7";
+
+    public static final String MESSAGE_EDIT_GROUP_SUCCESS = "Edited Group: %1$s";
+    public static final String MESSAGE_NOT_EDITED = "At least one edit field must be provided";
+    public static final String MESSAGE_DUPLICATE_GROUP = "This group already exists in Coder Life Insights";
+
+    private final Index index;
+    private final EditGroupDescriptor editGroupDescriptor;
+
+    public EditGroupCommand(Index index, EditGroupDescriptor editGroupDescriptor) {
+        requireNonNull(index);
+        requireNonNull(editGroupDescriptor);
+
+        this.index = index;
+        this.editGroupDescriptor = editGroupDescriptor;
+    }
+
+    @Override
+    public CommandResult execute(Model model) throws CommandException {
+        requireNonNull(model);
+        List<Group> lastShownList = model.getFilteredGroupList();
+
+        if (index.getZeroBased() >= lastShownList.size()) {
+            throw new CommandException(Messages.MESSAGE_INVALID_GROUP_DISPLAYED_INDEX);
+        }
+
+        Group groupToEdit = lastShownList.get(index.getZeroBased());
+        Group editedGroup = createEditedGroup(groupToEdit, editGroupDescriptor);
+
+        if (!groupToEdit.equals(editedGroup) && model.hasGroup(editedGroup)) {
+            throw new CommandException(MESSAGE_DUPLICATE_GROUP);
+        }
+
+        model.setGroup(groupToEdit, editedGroup);
+        model.updateFilteredGroupList(PREDICATE_SHOW_ALL_GROUPS);
+        return new CommandResult(String.format(MESSAGE_EDIT_GROUP_SUCCESS, editedGroup), ViewType.GROUPS);
+    }
+
+    /**
+     * Creates and returns a {@code Group} with the details of {@code groupToEdit}.
+     * @param groupToEdit
+     * @param editGroupDescriptor
+     * @return
+     */
+    private static Group createEditedGroup(Group groupToEdit, EditGroupDescriptor editGroupDescriptor) {
+        assert groupToEdit != null;
+
+        Name updatedName = editGroupDescriptor.getName().orElse(groupToEdit.getName());
+        Time oldTime = groupToEdit.getTimeSpent();
+        ArrayList<Integer> memberIds = editGroupDescriptor.getMemberIds().get();
+        ArrayList<Integer> eventIds = groupToEdit.getEvents();
+        int groupID = groupToEdit.getGroupId();
+
+        Group modifiedGroup = new Group(updatedName);
+        modifiedGroup.setTimeSpent(oldTime);
+        modifiedGroup.setMemberIDs(memberIds);
+        modifiedGroup.setEventIDs(eventIds);
+        modifiedGroup.setGroupId(groupID);
+
+        return modifiedGroup;
+    }
+
+
+    /**
+     * Stores the details to edit the group with. Each non-empty field value will replace the corresponding field value
+     * of the specified group.
+     */
+    public static class EditGroupDescriptor {
+        private Name name;
+        private ArrayList<Integer> memberIds;
+
+        public EditGroupDescriptor() {
+
+        }
+
+        public EditGroupDescriptor(EditGroupDescriptor toCopy) {
+            setName(toCopy.name);
+            setMemberIds(toCopy.memberIds);
+        }
+
+        /**
+         * Checks if at least one field is edited by user.
+         */
+        public boolean isAnyFieldEdited() {
+            return CollectionUtil.isAnyNonNull(name, memberIds);
+        }
+
+        public void setName(Name name) {
+            this.name = name;
+        }
+
+        public Optional<Name> getName() {
+            return Optional.ofNullable(this.name);
+        }
+
+        public void setMemberIds(ArrayList<Integer> memberIds) {
+            this.memberIds = (memberIds != null) ? new ArrayList<>(memberIds) : null;
+        }
+
+        public Optional<ArrayList<Integer>> getMemberIds() {
+            return (memberIds != null) ? Optional.of(memberIds) : Optional.empty();
+        }
+
+    }
+
+}

--- a/src/main/java/seedu/address/logic/commands/EditGroupCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditGroupCommand.java
@@ -94,7 +94,13 @@ public class EditGroupCommand extends Command{
 
         Name updatedName = editGroupDescriptor.getName().orElse(groupToEdit.getName());
         Time oldTime = groupToEdit.getTimeSpent();
-        ArrayList<Integer> memberIds = editGroupDescriptor.getMemberIds().get();
+        ArrayList<Integer> memberIds;
+        if (editGroupDescriptor.getMemberIds().isPresent()) {
+            memberIds = editGroupDescriptor.getMemberIds().get();
+        } else {
+            memberIds = groupToEdit.getMembers();
+        }
+
         ArrayList<Integer> eventIds = groupToEdit.getEvents();
         int groupID = groupToEdit.getGroupId();
 

--- a/src/main/java/seedu/address/logic/parser/AddressBookParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddressBookParser.java
@@ -6,23 +6,7 @@ import static seedu.address.commons.core.Messages.MESSAGE_UNKNOWN_COMMAND;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-import seedu.address.logic.commands.AddCommand;
-import seedu.address.logic.commands.AddEventCommand;
-import seedu.address.logic.commands.AddGroupCommand;
-import seedu.address.logic.commands.ClearCommand;
-import seedu.address.logic.commands.Command;
-import seedu.address.logic.commands.DeleteCommand;
-import seedu.address.logic.commands.DeleteGroupCommand;
-import seedu.address.logic.commands.EditCommand;
-import seedu.address.logic.commands.ExitCommand;
-import seedu.address.logic.commands.ExportCommand;
-import seedu.address.logic.commands.FindCommand;
-import seedu.address.logic.commands.HelpCommand;
-import seedu.address.logic.commands.ImportCommand;
-import seedu.address.logic.commands.ListCommand;
-import seedu.address.logic.commands.ListGroupCommand;
-import seedu.address.logic.commands.SuggestCommand;
-import seedu.address.logic.commands.ViewCommand;
+import seedu.address.logic.commands.*;
 import seedu.address.logic.parser.exceptions.ParseException;
 
 /**
@@ -59,6 +43,9 @@ public class AddressBookParser {
         case EditCommand.COMMAND_WORD:
             return new EditCommandParser().parse(arguments);
 
+        case EditGroupCommand.COMMAND_WORD:
+            return new EditGroupCommandParser().parse(arguments);
+
         case DeleteCommand.COMMAND_WORD:
             return new DeleteCommandParser().parse(arguments);
 
@@ -91,8 +78,6 @@ public class AddressBookParser {
 
         case HelpCommand.COMMAND_WORD:
             return new HelpCommand();
-        //        case RandomCommand.COMMAND_WORD:
-            //        return new RandomCommand();
 
         case ViewCommand.COMMAND_WORD:
             return new ViewCommandParser().parse(arguments);

--- a/src/main/java/seedu/address/logic/parser/AddressBookParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddressBookParser.java
@@ -6,7 +6,24 @@ import static seedu.address.commons.core.Messages.MESSAGE_UNKNOWN_COMMAND;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-import seedu.address.logic.commands.*;
+import seedu.address.logic.commands.AddCommand;
+import seedu.address.logic.commands.AddEventCommand;
+import seedu.address.logic.commands.AddGroupCommand;
+import seedu.address.logic.commands.ClearCommand;
+import seedu.address.logic.commands.Command;
+import seedu.address.logic.commands.DeleteCommand;
+import seedu.address.logic.commands.DeleteGroupCommand;
+import seedu.address.logic.commands.EditCommand;
+import seedu.address.logic.commands.EditGroupCommand;
+import seedu.address.logic.commands.ExitCommand;
+import seedu.address.logic.commands.ExportCommand;
+import seedu.address.logic.commands.FindCommand;
+import seedu.address.logic.commands.HelpCommand;
+import seedu.address.logic.commands.ImportCommand;
+import seedu.address.logic.commands.ListCommand;
+import seedu.address.logic.commands.ListGroupCommand;
+import seedu.address.logic.commands.SuggestCommand;
+import seedu.address.logic.commands.ViewCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
 
 /**

--- a/src/main/java/seedu/address/logic/parser/EditGroupCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/EditGroupCommandParser.java
@@ -50,6 +50,10 @@ public class EditGroupCommandParser implements Parser<EditGroupCommand> {
             ArrayList<Integer> memberIds = new ArrayList<>(memberIDs);
             editGroupDescriptor.setMemberIds(memberIds);
         }
+
+        if (!editGroupDescriptor.isAnyFieldEdited()) {
+            throw new ParseException(EditGroupCommand.MESSAGE_NOT_EDITED);
+        }
         return new EditGroupCommand(index, editGroupDescriptor);
     }
 

--- a/src/main/java/seedu/address/logic/parser/EditGroupCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/EditGroupCommandParser.java
@@ -1,0 +1,63 @@
+package seedu.address.logic.parser;
+
+import static java.util.Objects.requireNonNull;
+import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_MEMBER;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import seedu.address.commons.core.index.Index;
+import seedu.address.logic.commands.EditGroupCommand;
+import seedu.address.logic.commands.EditGroupCommand.EditGroupDescriptor;
+import seedu.address.logic.parser.exceptions.ParseException;
+/**
+ * Parses input arguments and creates a new EditGroupCommand instance.
+ */
+public class EditGroupCommandParser implements Parser<EditGroupCommand> {
+    /**
+     * Parses the given {@code String} of arguments in the context of the EditGroupCommand and returns an
+     * EditGroupCommand instance for execution.
+     * @param args
+     * @return
+     * @throws ParseException
+     */
+    public EditGroupCommand parse(String args) throws ParseException {
+        requireNonNull(args);
+        ArgumentMultimap argumentMultimap = ArgumentTokenizer.tokenize(
+                args, PREFIX_NAME, PREFIX_MEMBER);
+
+        Index index;
+
+        try {
+            index = ParserUtil.parseIndex(argumentMultimap.getPreamble());
+        } catch (ParseException pe) {
+            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, EditGroupCommand.MESSAGE_USAGE), pe);
+        }
+
+        EditGroupDescriptor editGroupDescriptor = new EditGroupDescriptor();
+        if (argumentMultimap.getValue(PREFIX_NAME).isPresent()) {
+            editGroupDescriptor.setName(ParserUtil.parseName(argumentMultimap.getValue(PREFIX_NAME).get()));
+        }
+        if (arePrefixesPresent(argumentMultimap, PREFIX_MEMBER)) {
+            List<String> members = argumentMultimap.getAllValues(PREFIX_MEMBER);
+            List<Integer> memberIDs = members.stream()
+                                                  .map(s -> Integer.valueOf(s))
+                                                  .collect(Collectors.toList());
+            ArrayList<Integer> memberIds = new ArrayList<>(memberIDs);
+            editGroupDescriptor.setMemberIds(memberIds);
+        }
+        return new EditGroupCommand(index, editGroupDescriptor);
+    }
+
+    /**
+     * Returns true if none of the prefixes contains empty {@code Optional} values in the given {@code
+     * ArgumentMultimap}.
+     */
+    private static boolean arePrefixesPresent(ArgumentMultimap argumentMultimap, Prefix... prefixes) {
+        return Stream.of(prefixes).allMatch(prefix -> argumentMultimap.getValue(prefix).isPresent());
+    }
+}

--- a/src/main/java/seedu/address/model/event/Event.java
+++ b/src/main/java/seedu/address/model/event/Event.java
@@ -83,7 +83,8 @@ public class Event {
                 && this.getPlace().equalsIgnoreCase(otherEvent.getPlace())
                 && this.getTime().equals(otherEvent.getTime())
                 && this.getWithGroup().equals(otherEvent.getWithGroup())
-                && this.getWithPerson().equals(otherEvent.getWithPerson());
+                && this.getWithPerson().equals(otherEvent.getWithPerson())
+                && this.getEventId() == (otherEvent.getEventId());
     }
 
     @Override

--- a/src/main/java/seedu/address/model/group/Group.java
+++ b/src/main/java/seedu/address/model/group/Group.java
@@ -35,6 +35,10 @@ public class Group {
         return this.name;
     }
 
+    public void setGroupId(int groupId) {
+        this.groupId = groupId;
+    }
+
     public int getGroupId() {
         return this.groupId;
     }

--- a/src/test/java/seedu/address/logic/commands/AddEventCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddEventCommandTest.java
@@ -84,7 +84,6 @@ public class AddEventCommandTest {
         final Model model = new ModelManager(getTypicalAddressBook(), new UserPrefs());
         final String activity = "test";
         final String place = "anywhere";
-        final Time time = new Time(30, 0);
         Index outOfBoundIndex = Index.fromOneBased(model.getFilteredPersonList().size() + 1);
 
         Event event = new Event(activity, place, 30, 0);

--- a/src/test/java/seedu/address/logic/commands/EditGroupCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/EditGroupCommandTest.java
@@ -1,0 +1,4 @@
+package seedu.address.logic.commands;
+
+public class EditGroupCommandTest {
+}

--- a/src/test/java/seedu/address/logic/parser/EditGroupCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/EditGroupCommandParserTest.java
@@ -1,0 +1,4 @@
+package seedu.address.logic.parser;
+
+public class EditGroupCommandParserTest {
+}

--- a/src/test/java/seedu/address/testutil/GroupBuilder.java
+++ b/src/test/java/seedu/address/testutil/GroupBuilder.java
@@ -1,0 +1,106 @@
+package seedu.address.testutil;
+
+import java.util.ArrayList;
+
+import seedu.address.logic.parser.ParserUtil;
+import seedu.address.model.group.Group;
+import seedu.address.model.person.Name;
+import seedu.address.model.person.Time;
+
+/**
+ * A utility class to help with building Group Objects.
+ */
+public class GroupBuilder {
+
+    public static final String DEFAULT_NAME = "SoC Friends";
+    public static final int DEFAULT_ID = 1;
+    public static final int DEFAULT_MINS = 1;
+    public static final int DEFAULT_HOURS = 1;
+    public static final ArrayList<Integer> DEFAULT_LIST = new ArrayList<>();
+
+    private Name name;
+    private int id;
+    private Time timeSpent;
+    private ArrayList<Integer> memberIds;
+    private ArrayList<Integer> eventIDs;
+
+    public GroupBuilder() {
+        this.name = new Name(DEFAULT_NAME);
+        this.id = DEFAULT_ID;
+        this.timeSpent = new Time(DEFAULT_MINS, DEFAULT_HOURS);
+        this.memberIds = DEFAULT_LIST;
+        this.eventIDs = DEFAULT_LIST;
+    }
+
+    public GroupBuilder(Group groupToCopy) {
+        name = groupToCopy.getName();
+        id = groupToCopy.getGroupId();
+        timeSpent = groupToCopy.getTimeSpent();
+        memberIds = groupToCopy.getMembers();
+        eventIDs = groupToCopy.getEvents();
+    }
+
+    /**
+     * Sets the code for name.
+     * @param name
+     * @return
+     */
+    public GroupBuilder withName(String name) {
+        this.name = new Name(name);
+        return this;
+    }
+
+    /**
+     * Sets the code for group Id.
+     * @param id
+     * @return
+     */
+    public GroupBuilder withId(int id) {
+        this.id = id;
+        return this;
+    }
+
+    /**
+     * Sets the code for time.
+     * @param time
+     * @return
+     */
+    public GroupBuilder withTime(String time) {
+        this.timeSpent = ParserUtil.parseTime(time);
+        return this;
+    }
+
+    /**
+     * Sets the code for withMembers.
+     * @param memberIds
+     * @return
+     */
+    public GroupBuilder withMembers(ArrayList<Integer> memberIds){
+        this.memberIds = memberIds;
+        return this;
+    }
+
+    /**
+     * Sets the code for withEvents.
+     * @param eventIDs
+     * @return
+     */
+    public GroupBuilder withEvents(ArrayList<Integer> eventIDs) {
+        this.eventIDs = eventIDs;
+        return this;
+    }
+
+    /**
+     * Builds a group with params in this class.
+     * @return
+     */
+    public Group build() {
+        Group group = new Group(name);
+        group.setGroupId(id);
+        group.setTimeSpent(timeSpent);
+        group.setMemberIDs(memberIds);
+        group.setEventIDs(eventIDs);
+        return group;
+    }
+
+}

--- a/src/test/java/seedu/address/testutil/GroupBuilder.java
+++ b/src/test/java/seedu/address/testutil/GroupBuilder.java
@@ -75,7 +75,7 @@ public class GroupBuilder {
      * @param memberIds
      * @return
      */
-    public GroupBuilder withMembers(ArrayList<Integer> memberIds){
+    public GroupBuilder withMembers(ArrayList<Integer> memberIds) {
         this.memberIds = memberIds;
         return this;
     }

--- a/src/test/java/seedu/address/testutil/TypicalGroups.java
+++ b/src/test/java/seedu/address/testutil/TypicalGroups.java
@@ -1,12 +1,35 @@
 package seedu.address.testutil;
 
-import seedu.address.model.group.Group;
-import seedu.address.model.person.Name;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
 
+import seedu.address.model.AddressBook;
+import seedu.address.model.group.Group;
 /**
  * A utility class containing list of {@code Group} objects to be used in tests.
  */
 public class TypicalGroups {
 
-    public static final Group SOC = new Group(new Name("SoC Friends"));
+    public static final Group SOC = new GroupBuilder().withName("SoC Friends").withId(1).withTime("1h 1m").build();
+    public static final Group RC = new GroupBuilder().withName("RC Friends").withId(2).withTime("2h 2m").build();
+    public static final Group NS = new GroupBuilder().withName("NS Friends").withId(3).withTime("0h 30m").build();
+
+    private TypicalGroups() {
+    }
+
+    /**
+     * Returns an {@code AddressBook} with all the typical groups
+     */
+    public static AddressBook getTypicalAddressBook() {
+        AddressBook ab = new AddressBook();
+        for (Group group : getTypicalGroups()) {
+            ab.addGroup(group);
+        }
+        return ab;
+    }
+
+    public static List<Group> getTypicalGroups() {
+        return new ArrayList<>(Arrays.asList(SOC, RC, NS));
+    }
 }

--- a/src/test/java/seedu/address/testutil/TypicalGroups.java
+++ b/src/test/java/seedu/address/testutil/TypicalGroups.java
@@ -1,0 +1,12 @@
+package seedu.address.testutil;
+
+import seedu.address.model.group.Group;
+import seedu.address.model.person.Name;
+
+/**
+ * A utility class containing list of {@code Group} objects to be used in tests.
+ */
+public class TypicalGroups {
+
+    public static final Group SOC = new Group(new Name("SoC Friends"));
+}


### PR DESCRIPTION
With`edit_group` a user can change the name of a group (identified by index), add or remove persons (identified by index). 