### PR TITLE
Add more test cases for DeleteGroupCommand

### DIFF
--- a/src/main/java/seedu/address/logic/commands/DeleteGroupCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DeleteGroupCommand.java
@@ -24,7 +24,7 @@ public class DeleteGroupCommand extends Command {
                     + COMMAND_WORD
                     + " 1";
 
-    public static final String MESSAGE_DELETE_PERSON_SUCCESS = "Deleted Group: %1$s";
+    public static final String MESSAGE_DELETE_GROUP_SUCCESS = "Deleted Group: %1$s";
 
     private final Index targetIndex;
 
@@ -43,7 +43,7 @@ public class DeleteGroupCommand extends Command {
 
         Group groupToDelete = lastShownList.get(targetIndex.getZeroBased());
         model.deleteGroup(groupToDelete);
-        return new CommandResult(String.format(MESSAGE_DELETE_PERSON_SUCCESS, groupToDelete));
+        return new CommandResult(String.format(MESSAGE_DELETE_GROUP_SUCCESS, groupToDelete));
     }
 
     @Override

--- a/src/main/java/seedu/address/logic/commands/DeleteGroupCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DeleteGroupCommand.java
@@ -43,7 +43,7 @@ public class DeleteGroupCommand extends Command {
 
         Group groupToDelete = lastShownList.get(targetIndex.getZeroBased());
         model.deleteGroup(groupToDelete);
-        return new CommandResult(String.format(MESSAGE_DELETE_PERSON_SUCCESS, groupToDelete), ViewType.GROUPS);
+        return new CommandResult(String.format(MESSAGE_DELETE_PERSON_SUCCESS, groupToDelete));
     }
 
     @Override

--- a/src/main/java/seedu/address/model/group/GroupNameContainsKeywordsPredicate.java
+++ b/src/main/java/seedu/address/model/group/GroupNameContainsKeywordsPredicate.java
@@ -7,10 +7,10 @@ import seedu.address.commons.util.StringUtil;
 /**
  * Checks if a {@code Group}'s {@code Name} matches any of the given keywords.
  */
-public class NameContainsKeywordsPredicate implements Predicate<Group> {
+public class GroupNameContainsKeywordsPredicate implements Predicate<Group> {
     private final List<String> keywords;
 
-    public NameContainsKeywordsPredicate(List<String> keywords) {
+    public GroupNameContainsKeywordsPredicate(List<String> keywords) {
         this.keywords = keywords;
     }
 
@@ -26,11 +26,11 @@ public class NameContainsKeywordsPredicate implements Predicate<Group> {
             return true;
         }
 
-        if (!(other instanceof NameContainsKeywordsPredicate)) {
+        if (!(other instanceof GroupNameContainsKeywordsPredicate)) {
             return false;
         }
 
-        NameContainsKeywordsPredicate nameContainsKeywordsPredicate = (NameContainsKeywordsPredicate) other;
+        GroupNameContainsKeywordsPredicate nameContainsKeywordsPredicate = (GroupNameContainsKeywordsPredicate) other;
         return this.keywords.equals(nameContainsKeywordsPredicate.keywords);
     }
 }

--- a/src/main/java/seedu/address/model/group/NameContainsKeywordsPredicate.java
+++ b/src/main/java/seedu/address/model/group/NameContainsKeywordsPredicate.java
@@ -1,0 +1,36 @@
+package seedu.address.model.group;
+
+import java.util.List;
+import java.util.function.Predicate;
+
+import seedu.address.commons.util.StringUtil;
+/**
+ * Checks if a {@code Group}'s {@code Name} matches any of the given keywords.
+ */
+public class NameContainsKeywordsPredicate implements Predicate<Group> {
+    private final List<String> keywords;
+
+    public NameContainsKeywordsPredicate(List<String> keywords) {
+        this.keywords = keywords;
+    }
+
+    @Override
+    public boolean test(Group group) {
+        return keywords.stream()
+                .anyMatch(keyword -> StringUtil.containsWordIgnoreCase(group.getName().fullName, keyword));
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+
+        if (!(other instanceof NameContainsKeywordsPredicate)) {
+            return false;
+        }
+
+        NameContainsKeywordsPredicate nameContainsKeywordsPredicate = (NameContainsKeywordsPredicate) other;
+        return this.keywords.equals(nameContainsKeywordsPredicate.keywords);
+    }
+}

--- a/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
+++ b/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
@@ -18,6 +18,7 @@ import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.AddressBook;
 import seedu.address.model.Model;
 import seedu.address.model.group.Group;
+import seedu.address.model.group.GroupNameContainsKeywordsPredicate;
 import seedu.address.model.person.NameContainsKeywordsPredicate;
 import seedu.address.model.person.Person;
 import seedu.address.testutil.EditPersonDescriptorBuilder;
@@ -150,12 +151,16 @@ public class CommandTestUtil {
         assertEquals(1, model.getFilteredPersonList().size());
     }
 
+    /**
+     * Updates {@code model}'s filtered list to show only the group at the given {@code targetIndex}
+     * @param model the current model
+     * @param targetIndex the targetted index
+     */
     public static void showGroupAtIndex(Model model, Index targetIndex) {
         assertTrue(targetIndex.getZeroBased() < model.getFilteredGroupList().size());
 
         Group group = model.getFilteredGroupList().get(targetIndex.getZeroBased());
         final String[] splitName = group.getName().fullName.split("\\s+");
-        model.updateFilteredGroupList(new NameContainsKeywordsPredicate(Arrays.asList(splitName[0])));
-        model.updateFilteredGroupList(g -> g.getName().contains);
+        model.updateFilteredGroupList(new GroupNameContainsKeywordsPredicate(Arrays.asList(splitName[0])));
     }
 }

--- a/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
+++ b/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
@@ -17,6 +17,7 @@ import seedu.address.commons.core.index.Index;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.AddressBook;
 import seedu.address.model.Model;
+import seedu.address.model.group.Group;
 import seedu.address.model.person.NameContainsKeywordsPredicate;
 import seedu.address.model.person.Person;
 import seedu.address.testutil.EditPersonDescriptorBuilder;
@@ -97,6 +98,8 @@ public class CommandTestUtil {
             Model expectedModel) {
         try {
             CommandResult result = command.execute(actualModel);
+            System.out.println("Expected feedback to user: " + expectedCommandResult.getFeedbackToUser());
+            System.out.println("Actual feedback to user" + result.getFeedbackToUser());
             assertEquals(expectedCommandResult, result);
             assertEquals(expectedModel, actualModel);
         } catch (CommandException ce) {
@@ -145,5 +148,14 @@ public class CommandTestUtil {
         model.updateFilteredPersonList(new NameContainsKeywordsPredicate(Arrays.asList(splitName[0])));
 
         assertEquals(1, model.getFilteredPersonList().size());
+    }
+
+    public static void showGroupAtIndex(Model model, Index targetIndex) {
+        assertTrue(targetIndex.getZeroBased() < model.getFilteredGroupList().size());
+
+        Group group = model.getFilteredGroupList().get(targetIndex.getZeroBased());
+        final String[] splitName = group.getName().fullName.split("\\s+");
+        model.updateFilteredGroupList(new NameContainsKeywordsPredicate(Arrays.asList(splitName[0])));
+        model.updateFilteredGroupList(g -> g.getName().contains);
     }
 }

--- a/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
+++ b/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
@@ -100,7 +100,7 @@ public class CommandTestUtil {
             assertEquals(expectedCommandResult, result);
             assertEquals(expectedModel, actualModel);
         } catch (CommandException ce) {
-            throw new AssertionError("Execution of command should not fail.", ce);
+            throw new AssertionError(ce.getMessage(), ce);
         }
     }
 

--- a/src/test/java/seedu/address/logic/commands/DeleteGroupCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/DeleteGroupCommandTest.java
@@ -4,6 +4,7 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.address.logic.commands.CommandTestUtil.assertCommandFailure;
 import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
+import static seedu.address.logic.commands.CommandTestUtil.showGroupAtIndex;
 import static seedu.address.testutil.TypicalGroups.getTypicalAddressBook;
 
 import org.junit.jupiter.api.Test;
@@ -23,7 +24,7 @@ public class DeleteGroupCommandTest {
     public void execute_validIndexUnfilteredList_success() {
         Group groupToDelete = model.getFilteredGroupList().get(0);
         DeleteGroupCommand deleteGroupCommand = new DeleteGroupCommand(Index.fromOneBased(1));
-        String expectedMessage = String.format(DeleteGroupCommand.MESSAGE_DELETE_PERSON_SUCCESS, groupToDelete);
+        String expectedMessage = String.format(DeleteGroupCommand.MESSAGE_DELETE_GROUP_SUCCESS, groupToDelete);
         ModelManager expectedModel = new ModelManager(model.getAddressBook(), new UserPrefs());
         expectedModel.deleteGroup(groupToDelete);
         assertCommandSuccess(deleteGroupCommand, model, expectedMessage, expectedModel);
@@ -38,9 +39,23 @@ public class DeleteGroupCommandTest {
     }
 
     @Test
-    public void execute_invalidIndexFilteredList_success() {
-        showGRou
+    public void execute_validIndexFilteredList_success() {
+        Index targetIndex = Index.fromOneBased(1);
+        showGroupAtIndex(model, targetIndex);
+
+        Group groupToDelete = model.getFilteredGroupList().get(targetIndex.getZeroBased());
+        DeleteGroupCommand deleteGroupCommand = new DeleteGroupCommand(targetIndex);
+
+        String expectedMessage = String.format(DeleteGroupCommand.MESSAGE_DELETE_GROUP_SUCCESS, groupToDelete);
+
+        Model expectedModel = new ModelManager(model.getAddressBook(), new UserPrefs());
+        expectedModel.deleteGroup(groupToDelete);
+        showNoGroup(expectedModel);
+
+        assertCommandSuccess(deleteGroupCommand, model, expectedMessage, expectedModel);
     }
+
+    
 
 
     @Test

--- a/src/test/java/seedu/address/logic/commands/DeleteGroupCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/DeleteGroupCommandTest.java
@@ -2,12 +2,41 @@ package seedu.address.logic.commands;
 
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static seedu.address.logic.commands.CommandTestUtil.assertCommandFailure;
+import static seedu.address.testutil.TypicalGroups.getTypicalAddressBook;
 
 import org.junit.jupiter.api.Test;
 
+import seedu.address.commons.core.Messages;
 import seedu.address.commons.core.index.Index;
+import seedu.address.model.Model;
+import seedu.address.model.ModelManager;
+import seedu.address.model.UserPrefs;
 
 public class DeleteGroupCommandTest {
+
+    private Model model = new ModelManager(getTypicalAddressBook(), new UserPrefs());
+
+    //    @Test
+    //    public void execute_validIndexUnfilteredList_success() {
+    //        Group groupToDelete = model.getFilteredGroupList().get(0);
+    //        DeleteGroupCommand deleteGroupCommand = new DeleteGroupCommand(Index.fromZeroBased(1));
+    //        String expectedMessage = String.format(DeleteGroupCommand.MESSAGE_DELETE_PERSON_SUCCESS, groupToDelete);
+    //
+    //        ModelManager expectedModel = new ModelManager(model.getAddressBook(), new UserPrefs());
+    //        expectedModel.deleteGroup(groupToDelete);
+    //
+    //        assertCommandSuccess(deleteGroupCommand, model, expectedMessage, expectedModel);
+    //    }
+
+    @Test
+    public void execute_invalidIndexUnfilteredList_throwsCommandException() {
+        Index outOfBoundIndex = Index.fromOneBased(model.getFilteredGroupList().size() + 1);
+        DeleteGroupCommand deleteGroupCommand = new DeleteGroupCommand(outOfBoundIndex);
+
+        assertCommandFailure(deleteGroupCommand, model, Messages.MESSAGE_INVALID_GROUP_DISPLAYED_INDEX);
+    }
+
 
     @Test
     public void equals() {

--- a/src/test/java/seedu/address/logic/commands/DeleteGroupCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/DeleteGroupCommandTest.java
@@ -3,6 +3,7 @@ package seedu.address.logic.commands;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.address.logic.commands.CommandTestUtil.assertCommandFailure;
+import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
 import static seedu.address.testutil.TypicalGroups.getTypicalAddressBook;
 
 import org.junit.jupiter.api.Test;
@@ -12,22 +13,21 @@ import seedu.address.commons.core.index.Index;
 import seedu.address.model.Model;
 import seedu.address.model.ModelManager;
 import seedu.address.model.UserPrefs;
+import seedu.address.model.group.Group;
 
 public class DeleteGroupCommandTest {
 
     private Model model = new ModelManager(getTypicalAddressBook(), new UserPrefs());
 
-    //    @Test
-    //    public void execute_validIndexUnfilteredList_success() {
-    //        Group groupToDelete = model.getFilteredGroupList().get(0);
-    //        DeleteGroupCommand deleteGroupCommand = new DeleteGroupCommand(Index.fromZeroBased(1));
-    //        String expectedMessage = String.format(DeleteGroupCommand.MESSAGE_DELETE_PERSON_SUCCESS, groupToDelete);
-    //
-    //        ModelManager expectedModel = new ModelManager(model.getAddressBook(), new UserPrefs());
-    //        expectedModel.deleteGroup(groupToDelete);
-    //
-    //        assertCommandSuccess(deleteGroupCommand, model, expectedMessage, expectedModel);
-    //    }
+    @Test
+    public void execute_validIndexUnfilteredList_success() {
+        Group groupToDelete = model.getFilteredGroupList().get(0);
+        DeleteGroupCommand deleteGroupCommand = new DeleteGroupCommand(Index.fromOneBased(1));
+        String expectedMessage = String.format(DeleteGroupCommand.MESSAGE_DELETE_PERSON_SUCCESS, groupToDelete);
+        ModelManager expectedModel = new ModelManager(model.getAddressBook(), new UserPrefs());
+        expectedModel.deleteGroup(groupToDelete);
+        assertCommandSuccess(deleteGroupCommand, model, expectedMessage, expectedModel);
+    }
 
     @Test
     public void execute_invalidIndexUnfilteredList_throwsCommandException() {
@@ -37,13 +37,22 @@ public class DeleteGroupCommandTest {
         assertCommandFailure(deleteGroupCommand, model, Messages.MESSAGE_INVALID_GROUP_DISPLAYED_INDEX);
     }
 
+    @Test
+    public void execute_invalidIndexFilteredList_success() {
+        showGRou
+    }
+
 
     @Test
     public void equals() {
         DeleteGroupCommand deleteGroupCommand1 = new DeleteGroupCommand(Index.fromZeroBased(0));
         DeleteGroupCommand deleteGroupCommand2 = new DeleteGroupCommand(Index.fromZeroBased(1));
 
-        //check equals method
+        //same values -> returns true
+        DeleteGroupCommand deleteGroupCommand1Copy = new DeleteGroupCommand(Index.fromZeroBased(0));
+        assertTrue(deleteGroupCommand1Copy.equals(deleteGroupCommand1));
+
+        //same object -> returns true
         assertTrue(deleteGroupCommand1.equals(deleteGroupCommand1));
 
         // different types -> returns false
@@ -51,6 +60,15 @@ public class DeleteGroupCommandTest {
 
         // different groups -> returns false
         assertFalse(deleteGroupCommand1.equals(deleteGroupCommand2));
+
+        // null object -> return false
+        assertFalse(deleteGroupCommand1.equals(null));
+    }
+
+    private void showNoGroup(Model model) {
+        model.updateFilteredGroupList(p -> false);
+
+        assertTrue(model.getFilteredGroupList().isEmpty());
     }
 
 }

--- a/src/test/java/seedu/address/logic/commands/DeleteGroupCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/DeleteGroupCommandTest.java
@@ -19,7 +19,7 @@ import seedu.address.model.group.Group;
 public class DeleteGroupCommandTest {
 
     private Model model = new ModelManager(getTypicalAddressBook(), new UserPrefs());
-
+    private Index targetIndex = Index.fromOneBased(1);
     @Test
     public void execute_validIndexUnfilteredList_success() {
         Group groupToDelete = model.getFilteredGroupList().get(0);
@@ -40,7 +40,6 @@ public class DeleteGroupCommandTest {
 
     @Test
     public void execute_validIndexFilteredList_success() {
-        Index targetIndex = Index.fromOneBased(1);
         showGroupAtIndex(model, targetIndex);
 
         Group groupToDelete = model.getFilteredGroupList().get(targetIndex.getZeroBased());
@@ -55,7 +54,14 @@ public class DeleteGroupCommandTest {
         assertCommandSuccess(deleteGroupCommand, model, expectedMessage, expectedModel);
     }
 
-    
+    @Test
+    public void execute_invalidIndexFilteredList_throwsCommandException() {
+        showGroupAtIndex(model, targetIndex);
+        Index outOfBounds = Index.fromOneBased(2);
+        assertTrue(outOfBounds.getZeroBased() < model.getAddressBook().getGroupList().size());
+        DeleteGroupCommand deleteGroupCommand = new DeleteGroupCommand(outOfBounds);
+        assertCommandFailure(deleteGroupCommand, model, Messages.MESSAGE_INVALID_GROUP_DISPLAYED_INDEX);
+    }
 
 
     @Test


### PR DESCRIPTION
This PR adds more unit tests for the `DeleteGroupCommand`. Since the functionality of this command is similar to the `DeleteCommand`, it takes inspiration from the test case design of the `DeleteCommand`. 